### PR TITLE
Added arm ids list

### DIFF
--- a/lib/multi_armed_bandit/mp_ts.rb
+++ b/lib/multi_armed_bandit/mp_ts.rb
@@ -6,35 +6,39 @@ module MultiArmedBandit
 
     attr_accessor :k, :l, :alpha, :beta, :last_selected_arms
 
-    # Initialize an object
     # k: num of arms
     # l: num of selected arms
     def initialize(k, l)
       @k = k
       @l = l
+      @r = SimpleRandom.new
       reset
     end
 
-    # Reset instance variables
     def reset
       @alpha = Array.new(@k, 1)
       @beta = Array.new(@k, 1)
-      @last_selected_arms = Array.new(@l, 0)
-      @r = SimpleRandom.new
+      @arm_ids = Array.new(@k, '')
     end
 
+    # Get selected arm ids
     def get_selected_arms
-      selected_arms = @alpha.zip(@beta).each_with_index
-                      .map{|c,i| [i, @r.beta(c[0],c[1]) ]}
+      selected_arms = @alpha.zip(@beta).zip(@arm_ids)
+                      .map{|c,i| [i, @r.beta(c[0],c[1])]}
                       .sort_by{|v| -v[1]}
                       .map{|v| v[0]}[0..@l-1]
-      @last_selected_arms = selected_arms
     end
 
-    # idx: index number of clicked arm
-    def update_params(idx)
-      @last_selected_arms.map{|i| i==idx ? @alpha[i]+=1 : @beta[i]+=1}
+    # selected_arms: List of selected drawn arms
+    def update_params_draw(selected_arms)
+      selected_arms.map{|i| @beta[i]+=1}
     end
 
+    # idx: Index number of rewarded arm
+    def update_params_reward(idx)
+      @alpha[idx]+=1
+      @beta[idx]-=1
+    end
+    
   end
 end

--- a/lib/multi_armed_bandit/mp_ts.rb
+++ b/lib/multi_armed_bandit/mp_ts.rb
@@ -4,7 +4,7 @@ module MultiArmedBandit
 
   class MultiplePlayTS
 
-    attr_accessor :k, :l, :alpha, :beta, :last_selected_arms
+    attr_accessor :k, :l, :alpha, :beta
 
     # k: num of arms
     # l: num of selected arms

--- a/multi_armed_bandit.gemspec
+++ b/multi_armed_bandit.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "simple-random"
 end

--- a/spec/mp_ts.rb
+++ b/spec/mp_ts.rb
@@ -11,18 +11,24 @@ describe MultiArmedBandit::MultiplePlayTS do
     expect(arms.count).to eq(l)
   end	
 
-  it 'Alpha update correctly works' do
+  it 'Beat update correctly works when arms draw' do
     mpts = MultiArmedBandit::MultiplePlayTS.new(k, l)
-    mpts.last_selected_arms = [1,3]
-    mpts.update_params(1)
-    expect(mpts.alpha).to eq([1,2,1,1,1])
+    mpts.update_params_draw([1,3])
+    expect(mpts.beta).to eq([1,2,1,2,1])
   end
 
-  it 'Beta update correctly works' do
+  it 'Alpha update correctly works when rewarded' do
     mpts = MultiArmedBandit::MultiplePlayTS.new(k, l)
-    mpts.last_selected_arms = [1,3]
-    mpts.update_params(1)
+    mpts.update_params_draw([1,3])
+    mpts.update_params_reward(1)
     expect(mpts.beta).to eq([1,1,1,2,1])
+  end
+
+  it 'Alpha update correctly works when rewarded' do
+    mpts = MultiArmedBandit::MultiplePlayTS.new(k, l)
+    mpts.update_params_draw([1,3])
+    mpts.update_params_reward(1)
+    expect(mpts.alpha).to eq([1,2,1,1,1])
   end
 
 end 


### PR DESCRIPTION
Added arm ids list to the initialize method, which enables to identify arms by given ids instead of ordered index number.