### PR TITLE
gemのaddがdevelopmentでなく通常のaddにする

### DIFF
--- a/multi_armed_bandit.gemspec
+++ b/multi_armed_bandit.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "simple-random"
+  spec.add_dependency "simple-random"
 end


### PR DESCRIPTION
add_development_dependencyだと開発環境でしかinstallされないので、add_dependencyに変更する